### PR TITLE
AimingAndPosition instead of PositionAndRotation

### DIFF
--- a/Source/Ocp1DataTypes.cpp
+++ b/Source/Ocp1DataTypes.cpp
@@ -361,6 +361,11 @@ std::vector<std::uint8_t> DataFromPosition(std::float_t x, std::float_t y, std::
 
 std::vector<std::uint8_t> DataFromPositionAndRotation(std::float_t x, std::float_t y, std::float_t z, std::float_t hor, std::float_t vert, std::float_t rot)
 {
+    return DataFromAimingAndPosition(hor, vert, rot, x, y, z);
+}
+
+std::vector<std::uint8_t> DataFromAimingAndPosition(std::float_t hor, std::float_t vert, std::float_t rot, std::float_t x, std::float_t y, std::float_t z)
+{
     std::vector<std::uint8_t> ret;
     ret.reserve(6 * 4);
 

--- a/Source/Ocp1DataTypes.h
+++ b/Source/Ocp1DataTypes.h
@@ -208,24 +208,29 @@ std::vector<std::uint8_t> DataFromDouble(std::double_t doubleValue);
 /**
  * Convenience helper method to convert a 3D position (three 32-bit floats) into a byte vector
  *
- * @param[in] x     First value to be converted.
- * @param[in] y     Second value to be converted.
- * @param[in] z     Third value to be converted.
+ * @param[in] x     Position along x axis.
+ * @param[in] y     Position along y axis.
+ * @param[in] z     Position along z axis.
  * @return  The values as a byte vector.
  */
 std::vector<std::uint8_t> DataFromPosition(std::float_t x, std::float_t y, std::float_t z);
 
 /**
- * Convenience helper method to convert a 3D position and rotation (six 32-bit floats) into a byte vector
+ * Convenience helper method to convert a 3D aiming and position (six 32-bit floats) into a byte vector
+ * @note The aiming angles are marshaled first and the position second, to keep in line with the 
+ *       CdbOcaAimingAndPosition::Marshal method.
  *
- * @param[in] x     First value to be converted.
- * @param[in] y     Second value to be converted.
- * @param[in] z     Third value to be converted.
- * @param[in] hor   Fourth value to be converted.
- * @param[in] vert  Fifth value to be converted.
- * @param[in] rot   Sixth value to be converted.
+ * @param[in] hor   Horizontal aiming (yaw).
+ * @param[in] vert  Vertical aiming (pitch).
+ * @param[in] rot   Rotational aiming (roll).
+ * @param[in] x     Position along x axis.
+ * @param[in] y     Position along y axis.
+ * @param[in] z     Position along z axis.
  * @return  The values as a byte vector.
  */
+std::vector<std::uint8_t> DataFromAimingAndPosition(std::float_t hor, std::float_t vert, std::float_t rot, std::float_t x, std::float_t y, std::float_t z);
+
+[[deprecated("Use DataFromAimingAndPosition instead, this method will be removed in the future.")]]
 std::vector<std::uint8_t> DataFromPositionAndRotation(std::float_t x, std::float_t y, std::float_t z, std::float_t hor, std::float_t vert, std::float_t rot);
 
 /**

--- a/Source/Ocp1DataTypes.h
+++ b/Source/Ocp1DataTypes.h
@@ -230,7 +230,8 @@ std::vector<std::uint8_t> DataFromPosition(std::float_t x, std::float_t y, std::
  */
 std::vector<std::uint8_t> DataFromAimingAndPosition(std::float_t hor, std::float_t vert, std::float_t rot, std::float_t x, std::float_t y, std::float_t z);
 
-[[deprecated("Use DataFromAimingAndPosition instead, this method will be removed in the future.")]]
+[[deprecated("Use DataFromAimingAndPosition instead, this method will be removed in the future. "
+  "NOTE: The order of the input parameters in the new method has been changed to be more consistent with the marshaling order.")]]
 std::vector<std::uint8_t> DataFromPositionAndRotation(std::float_t x, std::float_t y, std::float_t z, std::float_t hor, std::float_t vert, std::float_t rot);
 
 /**

--- a/Source/Variant.cpp
+++ b/Source/Variant.cpp
@@ -18,6 +18,7 @@
 
 #include "Variant.h"
 #include <assert.h>
+#include <sstream>
 
 
 namespace NanoOcp1
@@ -639,6 +640,26 @@ std::array<std::float_t, 3> Variant::ToPosition(bool* pOk) const
 
     if (ok)
         ret[2] = NanoOcp1::DataToFloat(std::vector<std::uint8_t>(data.data() + 8, data.data() + 12), &ok); // z
+
+    if (pOk != nullptr)
+        *pOk = ok;
+
+    return ret;
+}
+
+std::string Variant::ToPositionString(bool* pOk) const
+{
+    bool ok;
+    std::string ret;
+
+    auto pos = ToPosition(&ok);
+    if (ok)
+    {
+        std::stringstream ss;
+        ss << pos[0] << ", " << pos[1] << ", " << pos[2];
+
+        ret = std::string(ss.str());
+    }
 
     if (pOk != nullptr)
         *pOk = ok;

--- a/Source/Variant.cpp
+++ b/Source/Variant.cpp
@@ -669,6 +669,11 @@ std::string Variant::ToPositionString(bool* pOk) const
 
 std::array<std::float_t, 6> Variant::ToPositionAndRotation(bool* pOk) const
 {
+    return ToAimingAndPosition(pOk);
+}
+
+std::array<std::float_t, 6> Variant::ToAimingAndPosition(bool* pOk) const
+{
     std::array<std::float_t, 6> ret{ 0.0f };
 
     if (m_value.index() != TypeByteVector)
@@ -680,25 +685,25 @@ std::array<std::float_t, 6> Variant::ToPositionAndRotation(bool* pOk) const
     }
 
     const auto& data = std::get<std::vector<std::uint8_t>>(m_value);
-    bool ok = (data.size() == 24); // Value contains 6 floats: x, y, z, horAngle, vertAngle, rotAngle.
+    bool ok = (data.size() == 24); // Value contains 6 floats: horAngle, vertAngle, rotAngle, x, y, z.
     
     if (ok)
-        ret[0] = NanoOcp1::DataToFloat(data, &ok); // x
+        ret[0] = NanoOcp1::DataToFloat(data, &ok); // hor
 
     if (ok)
-        ret[1] = NanoOcp1::DataToFloat(std::vector<std::uint8_t>(data.data() + 4, data.data() + 8), &ok); // y
+        ret[1] = NanoOcp1::DataToFloat(std::vector<std::uint8_t>(data.data() + 4, data.data() + 8), &ok); // ver
 
     if (ok)
-        ret[2] = NanoOcp1::DataToFloat(std::vector<std::uint8_t>(data.data() + 8, data.data() + 12), &ok); // z
+        ret[2] = NanoOcp1::DataToFloat(std::vector<std::uint8_t>(data.data() + 8, data.data() + 12), &ok); // rot
 
     if (ok)
-        ret[3] = NanoOcp1::DataToFloat(std::vector<std::uint8_t>(data.data() + 12, data.data() + 16), &ok); // hor
+        ret[3] = NanoOcp1::DataToFloat(std::vector<std::uint8_t>(data.data() + 12, data.data() + 16), &ok); // x
 
     if (ok)
-        ret[4] = NanoOcp1::DataToFloat(std::vector<std::uint8_t>(data.data() + 16, data.data() + 20), &ok); // ver
+        ret[4] = NanoOcp1::DataToFloat(std::vector<std::uint8_t>(data.data() + 16, data.data() + 20), &ok); // y
 
     if (ok)
-        ret[5] = NanoOcp1::DataToFloat(std::vector<std::uint8_t>(data.data() + 20, data.data() + 24), &ok); // rot
+        ret[5] = NanoOcp1::DataToFloat(std::vector<std::uint8_t>(data.data() + 20, data.data() + 24), &ok); // z
 
     if (pOk != nullptr)
         *pOk = ok;

--- a/Source/Variant.cpp
+++ b/Source/Variant.cpp
@@ -711,6 +711,27 @@ std::array<std::float_t, 6> Variant::ToAimingAndPosition(bool* pOk) const
     return ret;
 }
 
+std::string Variant::ToAimingAndPositionString(bool* pOk) const
+{
+    bool ok;
+    std::string ret;
+
+    auto pos = ToAimingAndPosition(&ok);
+    if (ok)
+    {
+        std::stringstream ss;
+        ss << pos[0] << ", " << pos[1] << ", " << pos[2] << ", " <<
+              pos[3] << ", " << pos[4] << ", " << pos[5];
+
+        ret = std::string(ss.str());
+    }
+
+    if (pOk != nullptr)
+        *pOk = ok;
+
+    return ret;
+}
+
 std::vector<bool> Variant::ToBoolVector(bool* pOk) const
 {
     std::vector<bool> boolVector;

--- a/Source/Variant.h
+++ b/Source/Variant.h
@@ -117,6 +117,14 @@ public:
     std::array<std::float_t, 3> ToPosition(bool* pOk = nullptr) const;
 
     /**
+     * Calls ToPosition and returns a human-readable string with the resulting position.
+     *
+     * @param[in] pOk   Optional parameter to verify if the conversion was successful.
+     * @return  A string in the format "x, y, z".
+     */
+    std::string ToPositionString(bool* pOk = nullptr) const;
+
+    /**
      * Convenience helper method to extract x, y, z, horizontal angle, vertical angle
      * and rotation angle float values from a Variant.
      *

--- a/Source/Variant.h
+++ b/Source/Variant.h
@@ -125,12 +125,17 @@ public:
     std::string ToPositionString(bool* pOk = nullptr) const;
 
     /**
-     * Convenience helper method to extract x, y, z, horizontal angle, vertical angle
-     * and rotation angle float values from a Variant.
+     * Convenience helper method to extract x, y, z, horizontal angle (yaw), 
+     * vertical angle (pitch) and rotation angle (roll) float values from a Variant.
+     * @note The aiming angles are unmarshaled first and the position second, to keep in line 
+     *       with the CdbOcaAimingAndPosition::Unmarshal method.
      *
      * @param[in] pOk   Optional parameter to verify if the conversion was successful.
-     * @return  The contained x, y, z, hor, ver, and rot values.
+     * @return  The contained values in the order: hor, ver, rot, x, y, z.
      */
+    std::array<std::float_t, 6> ToAimingAndPosition(bool* pOk = nullptr) const;
+
+    [[deprecated("Use ToAimingAndPosition instead, this method will be removed in the future.")]]
     std::array<std::float_t, 6> ToPositionAndRotation(bool* pOk = nullptr) const;
 
     /**

--- a/Source/Variant.h
+++ b/Source/Variant.h
@@ -117,9 +117,9 @@ public:
     std::array<std::float_t, 3> ToPosition(bool* pOk = nullptr) const;
 
     /**
-     * Calls ToPosition and returns a human-readable string with the resulting position.
+     * Calls ToPosition and returns a human-readable string with the result.
      *
-     * @param[in] pOk   Optional parameter to verify if the conversion was successful.
+     * @param[in] pOk   Optional parameter to verify if the ToPosition call was successful.
      * @return  A string in the format "x, y, z".
      */
     std::string ToPositionString(bool* pOk = nullptr) const;
@@ -137,6 +137,15 @@ public:
 
     [[deprecated("Use ToAimingAndPosition instead, this method will be removed in the future.")]]
     std::array<std::float_t, 6> ToPositionAndRotation(bool* pOk = nullptr) const;
+
+    /**
+     * Calls ToAimingAndPosition and returns a human-readable string with the result.
+     *
+     * @param[in] pOk   Optional parameter to verify if the ToAimingAndPosition call
+     *                  was successful.
+     * @return  A string in the format: "hor, ver, rot, x, y, z".
+     */
+    std::string ToAimingAndPositionString(bool* pOk = nullptr) const;
 
     /**
      * Convenience helper method to extract a std::vector<bool> from a from a Variant.

--- a/Source/Variant.h
+++ b/Source/Variant.h
@@ -135,7 +135,8 @@ public:
      */
     std::array<std::float_t, 6> ToAimingAndPosition(bool* pOk = nullptr) const;
 
-    [[deprecated("Use ToAimingAndPosition instead, this method will be removed in the future.")]]
+    [[deprecated("Use ToAimingAndPosition instead, this method will be removed in the future. " 
+      "NOTE: The output of both methods is identical, but the new method has a more consistent name.")]]
     std::array<std::float_t, 6> ToPositionAndRotation(bool* pOk = nullptr) const;
 
     /**


### PR DESCRIPTION
Naming and parameter ordering for loudspeaker positions was inconsistent with the AES70/OCA class CdbOcaAimingAndPosition

* Deprecated DataFromPositionAndRotation, added replacement: DataFromAimingAndPosition
* Deprecated ToPositionAndRotation, added replacement: ToAimingAndPosition
* Added helper ToPositionString
* Added helper ToAimingAndPositionString