### PR TITLE
Bugfix/purevirt

### DIFF
--- a/Source/NanoOcp1.cpp
+++ b/Source/NanoOcp1.cpp
@@ -75,8 +75,12 @@ NanoOcp1Client::NanoOcp1Client(const juce::String& address, const int port, cons
 
 NanoOcp1Client::~NanoOcp1Client()
 {
+    m_running = false;
+    stopTimer();
+
     // See comment in Ocp1Connection destructor. 
-    disconnect(4000, Notify::no);
+    if (isConnected())
+        disconnect(4000, Notify::no);
 }
 
 bool NanoOcp1Client::start()

--- a/Source/NanoOcp1.cpp
+++ b/Source/NanoOcp1.cpp
@@ -75,7 +75,8 @@ NanoOcp1Client::NanoOcp1Client(const juce::String& address, const int port, cons
 
 NanoOcp1Client::~NanoOcp1Client()
 {
-    stop();
+    // See comment in Ocp1Connection destructor. 
+    disconnect(4000, Notify::no);
 }
 
 bool NanoOcp1Client::start()

--- a/Source/NanoOcp1.cpp
+++ b/Source/NanoOcp1.cpp
@@ -79,8 +79,7 @@ NanoOcp1Client::~NanoOcp1Client()
     stopTimer();
 
     // See comment in Ocp1Connection destructor. 
-    if (isConnected())
-        disconnect(4000, Notify::no);
+    disconnect(4000, Notify::no);
 }
 
 bool NanoOcp1Client::start()

--- a/Source/Ocp1Connection.cpp
+++ b/Source/Ocp1Connection.cpp
@@ -140,14 +140,20 @@ bool Ocp1Connection::connectToSocket(const juce::String& hostName,
 
 void Ocp1Connection::disconnect(int timeoutMs, Notify notify)
 {
-    //should be called before socket->close to ensure that running processes on the thread
-    //are notified that the thread is about to exit.
-    thread->stopThread(timeoutMs);
+    if (thread != nullptr)
+    {
+        thread->signalThreadShouldExit();
+        thread->notify();
+    }
     
     {
         const juce::ScopedReadLock sl(socketLock);
-        if (socket != nullptr)  socket->close();
+        if (socket != nullptr)
+            socket->close();
     }
+
+    if (thread != nullptr && timeoutMs != 0)
+        jassert(thread->waitForThreadToExit(timeoutMs));
     
     deleteSocket();
 

--- a/Source/Ocp1Connection.cpp
+++ b/Source/Ocp1Connection.cpp
@@ -100,23 +100,10 @@ Ocp1Connection::~Ocp1Connection()
     // destroying the derived class, we'd end up calling the pure virtual implementations
     // of `messageReceived`, `connectionMade` and `connectionLost` which is definitely
     // not a good idea!
-
-    if (safeAction)
-        safeAction->setSafe(false);
     jassert(!safeAction->isSafe());
 
     callbackConnectionState = false;
-
-    auto needsDisconnect = false;
-
-    {
-        const juce::ScopedReadLock sl(socketLock);
-        needsDisconnect = socket != nullptr;
-    }
-
-    if (thread != nullptr && (thread->isThreadRunning() || needsDisconnect))
-        disconnect(4000, Notify::no);
-
+    disconnect(4000, Notify::no);
     thread.reset();
 }
 
@@ -140,21 +127,15 @@ bool Ocp1Connection::connectToSocket(const juce::String& hostName,
 
 void Ocp1Connection::disconnect(int timeoutMs, Notify notify)
 {
-    if (thread != nullptr)
-    {
-        thread->signalThreadShouldExit();
-        thread->notify();
-    }
-    
+    //should be called before socket->close to ensure that running processes on the thread
+    //are notified that the thread is about to exit.
+    thread->stopThread(timeoutMs);
+
     {
         const juce::ScopedReadLock sl(socketLock);
-        if (socket != nullptr)
-            socket->close();
+        if (socket != nullptr)  socket->close();
     }
 
-    if (thread != nullptr && timeoutMs != 0)
-        jassert(thread->waitForThreadToExit(timeoutMs));
-    
     deleteSocket();
 
     if (notify == Notify::yes)

--- a/Source/Ocp1Connection.cpp
+++ b/Source/Ocp1Connection.cpp
@@ -33,7 +33,18 @@ namespace NanoOcp1
 
 struct Ocp1Connection::ConnectionThread : public juce::Thread
 {
-    ConnectionThread(Ocp1Connection& c) : juce::Thread("JUCE IPC"), owner(c) {}
+    ConnectionThread(Ocp1Connection& c) 
+        : juce::Thread("Ocp1Connection::ConnectionThread"), 
+          owner(c) 
+    {
+    }
+
+    ~ConnectionThread() override
+    {
+        signalThreadShouldExit();
+        stopThread(4000);
+    }
+
     void run() override { owner.runThread(); }
 
     Ocp1Connection& owner;
@@ -93,6 +104,9 @@ Ocp1Connection::~Ocp1Connection()
     // destroying the derived class, we'd end up calling the pure virtual implementations
     // of `messageReceived`, `connectionMade` and `connectionLost` which is definitely
     // not a good idea!
+
+    if (safeAction)
+        safeAction->setSafe(false);
     jassert(!safeAction->isSafe());
 
     callbackConnectionState = false;

--- a/Source/Ocp1Connection.cpp
+++ b/Source/Ocp1Connection.cpp
@@ -39,11 +39,7 @@ struct Ocp1Connection::ConnectionThread : public juce::Thread
     {
     }
 
-    ~ConnectionThread() override
-    {
-        signalThreadShouldExit();
-        stopThread(4000);
-    }
+    ~ConnectionThread() override = default;
 
     void run() override { owner.runThread(); }
 
@@ -110,7 +106,17 @@ Ocp1Connection::~Ocp1Connection()
     jassert(!safeAction->isSafe());
 
     callbackConnectionState = false;
-    disconnect(4000, Notify::no);
+
+    auto needsDisconnect = false;
+
+    {
+        const juce::ScopedReadLock sl(socketLock);
+        needsDisconnect = socket != nullptr;
+    }
+
+    if (thread != nullptr && (thread->isThreadRunning() || needsDisconnect))
+        disconnect(4000, Notify::no);
+
     thread.reset();
 }
 

--- a/Source/Ocp1Message.h
+++ b/Source/Ocp1Message.h
@@ -74,11 +74,11 @@ struct Ocp1CommandDefinition
      * Standard struct constructor.
      */
     Ocp1CommandDefinition()
-        :   m_targetOno(static_cast<std::uint32_t>(0)),
-            m_propertyType(static_cast<std::uint16_t>(0)),
-            m_propertyDefLevel(static_cast<std::uint16_t>(0)),
-            m_propertyIndex(static_cast<std::uint16_t>(0)),
-            m_paramCount(static_cast<std::uint8_t>(0))
+        : Ocp1CommandDefinition(static_cast<std::uint32_t>(0),
+                                static_cast<std::uint16_t>(0),
+                                static_cast<std::uint16_t>(0),
+                                static_cast<std::uint16_t>(0),
+                                static_cast<std::uint8_t>(0))
     {
     }
 


### PR DESCRIPTION
Obwohl ich den SSCPLG Debug Crash nicht beheben konnte, hier ein paar Verbesserungen die sowieso eine gute Idee sind:
1. Verwendung von Notify::no im NanoOcp1Client Destructror
2. Umbenennung von ConnectionThread von "JUCE IPC" ins "Ocp1Connection::ConnectionThread", ums besser von echte JUCE IPC Threads zu differenzieren 
3. Ein Ocp1CommandDefinition Constructor ruft den anderen an